### PR TITLE
Export local package

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -73,4 +73,9 @@ function(configure_and_install configure_in_file_path namespace version_compare_
             "${ConfigPackageSource}/${PROJECT_NAME}-config-version.cmake"
             DESTINATION ${ConfigPackageDestination}
             COMPONENT Devel)
+
+    # local package
+    export(EXPORT ${PROJECT_NAME}Targets
+           NAMESPACE ${namespace}::
+           FILE ${ConfigPackageSource}/${PROJECT_NAME}-targets.cmake)
 endfunction()


### PR DESCRIPTION
With this, from a local clone's `build/` directory, one can use `find_package` to find the project if one assigns the `${PROJECT_NAME}_DIR` variable the `build/${PROJECT_NAME}/` absolute directory. Normally, that's just be the absolute `build/`, but `install.cmake` puts the necessary files within `${PROJECT_NAME}/`.

Resolves https://github.com/mpusz/units/issues/102.